### PR TITLE
Add meta tags, OG tags, and favicon (#12)

### DIFF
--- a/projects/dad-jokes/refactored/index.html
+++ b/projects/dad-jokes/refactored/index.html
@@ -4,6 +4,25 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dad Jokes</title>
+    <meta name="description" content="Groan-worthy dad jokes on demand. Get a random joke, save your favourites, and share the pain. Free, no sign-up, no ads." />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="Dad Jokes" />
+    <meta property="og:description" content="Groan-worthy dad jokes on demand. Get a random joke, save your favourites, and share the pain." />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="/og-image.png" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Dad Jokes" />
+    <meta name="twitter:description" content="Groan-worthy dad jokes on demand. Free, no sign-up, no ads." />
+    <meta name="twitter:image" content="/og-image.png" />
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+
+    <!-- Theme colour for mobile browsers -->
+    <meta name="theme-color" content="#686de0" />
   </head>
   <body>
     <div class="container">

--- a/projects/dad-jokes/refactored/public/favicon.svg
+++ b/projects/dad-jokes/refactored/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text y=".9em" font-size="90">😄</text>
+</svg>

--- a/projects/dad-jokes/refactored/public/og-image.svg
+++ b/projects/dad-jokes/refactored/public/og-image.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <rect width="1200" height="630" fill="#686de0"/>
+  <text x="600" y="280" text-anchor="middle" font-family="sans-serif" font-size="72" font-weight="bold" fill="white">😄 Dad Jokes</text>
+  <text x="600" y="380" text-anchor="middle" font-family="sans-serif" font-size="32" fill="rgba(255,255,255,0.8)">Groan-worthy jokes on demand</text>
+</svg>


### PR DESCRIPTION
## Summary
- Added `<meta name="description">` with copy from DECISIONS.md D14
- Added Open Graph tags (`og:title`, `og:description`, `og:type`, `og:image`)
- Added Twitter Card tags (`summary_large_image`)
- Added SVG emoji favicon (😄)
- Added `<meta name="theme-color">` for mobile browsers
- Created SVG OG image placeholder (1200x630)

## Note
OG image is currently SVG — most social platforms require PNG/JPG. A proper PNG should be generated before deployment. This is noted as a minor follow-up.

## Test plan
- [x] Build succeeds
- [ ] Favicon shows in browser tab
- [ ] Meta tags visible in page source

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)