### PR TITLE
Add error handling + resilient API layer (#7)

### DIFF
--- a/projects/dad-jokes/refactored/src/api.ts
+++ b/projects/dad-jokes/refactored/src/api.ts
@@ -1,23 +1,136 @@
-import { API_URL } from './constants.ts';
+import { API_URL, USER_AGENT, REQUEST_TIMEOUT_MS } from './constants.ts';
 import type { Joke, ApiResponse } from './types.ts';
+
+/**
+ * Custom error class for API failures.
+ * Distinguishes between network errors, HTTP errors, and validation errors.
+ */
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly type: 'network' | 'http' | 'timeout' | 'validation',
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+/**
+ * Type guard to validate API response shape.
+ * Defensive: don't trust the API to always return what we expect.
+ */
+function isValidApiResponse(data: unknown): data is ApiResponse {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'id' in data &&
+    'joke' in data &&
+    typeof (data as ApiResponse).id === 'string' &&
+    typeof (data as ApiResponse).joke === 'string'
+  );
+}
+
+/** Active AbortController for the current request, if any */
+let activeController: AbortController | null = null;
+
+/**
+ * Cancel any in-flight joke request.
+ * Called when the user clicks the button again before the previous
+ * request completes, preventing stale responses from appearing.
+ */
+export function cancelActiveRequest(): void {
+  if (activeController) {
+    activeController.abort();
+    activeController = null;
+  }
+}
 
 /**
  * Fetch a random joke from the icanhazdadjoke API.
  *
- * This is a direct port of the original tutorial code's fetch logic,
- * reorganised into a module. Behaviour is identical to the original.
+ * Resilient implementation with:
+ * - AbortController with configurable timeout
+ * - HTTP status code checking
+ * - Response shape validation
+ * - Typed error classification
+ * - User-Agent header per API recommendation
+ * - Cancel support for in-flight requests
+ *
+ * @throws {ApiError} On network failure, HTTP error, timeout, or invalid response
  */
 export async function fetchJoke(): Promise<Joke> {
-  const res = await fetch(API_URL, {
-    headers: {
-      Accept: 'application/json',
-    },
-  });
+  // Cancel any in-flight request
+  cancelActiveRequest();
 
-  const data: ApiResponse = await res.json();
+  // Create new controller for this request
+  activeController = new AbortController();
+  const { signal } = activeController;
 
-  return {
-    id: data.id,
-    joke: data.joke,
-  };
+  // Set up timeout
+  const timeoutId = setTimeout(() => {
+    activeController?.abort();
+  }, REQUEST_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(API_URL, {
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': USER_AGENT,
+      },
+      signal,
+    });
+
+    if (!res.ok) {
+      throw new ApiError(
+        `API returned ${res.status}`,
+        'http',
+        res.status,
+      );
+    }
+
+    const data: unknown = await res.json();
+
+    if (!isValidApiResponse(data)) {
+      throw new ApiError(
+        'API returned unexpected data shape',
+        'validation',
+      );
+    }
+
+    return {
+      id: data.id,
+      joke: data.joke,
+    };
+  } catch (error) {
+    // Re-throw ApiError as-is
+    if (error instanceof ApiError) {
+      throw error;
+    }
+
+    // Handle abort (timeout or manual cancel)
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new ApiError(
+        'Request timed out — the joke servers might be slow',
+        'timeout',
+      );
+    }
+
+    // Handle network errors (offline, DNS failure, etc.)
+    if (error instanceof TypeError) {
+      throw new ApiError(
+        'Network error — check your connection',
+        'network',
+      );
+    }
+
+    // Unknown error — wrap it
+    throw new ApiError(
+      'Something went wrong fetching a joke',
+      'network',
+    );
+  } finally {
+    clearTimeout(timeoutId);
+    activeController = null;
+  }
 }

--- a/projects/dad-jokes/refactored/src/main.ts
+++ b/projects/dad-jokes/refactored/src/main.ts
@@ -1,24 +1,29 @@
 import '@fontsource/roboto/latin-400.css';
 import '@fontsource/roboto/latin-700.css';
 import './style.css';
-import { fetchJoke } from './api.ts';
-import { renderJoke } from './ui.ts';
+import { fetchJoke, ApiError } from './api.ts';
+import { renderJoke, renderError } from './ui.ts';
 
 /**
  * Main entry point.
  *
- * Direct port of the original tutorial's wiring:
- * - Fetch a joke on page load
- * - Fetch a new joke on button click
- *
- * Behaviour is identical to the original — just reorganised into modules.
+ * Fetches a joke on page load and on button click.
+ * Handles errors gracefully with user-facing messages.
  */
 
-const jokeBtn = document.getElementById('jokeBtn');
+const jokeBtn = document.getElementById('jokeBtn') as HTMLButtonElement | null;
 
 async function generateJoke(): Promise<void> {
-  const joke = await fetchJoke();
-  renderJoke(joke.joke);
+  try {
+    const joke = await fetchJoke();
+    renderJoke(joke.joke);
+  } catch (error) {
+    if (error instanceof ApiError) {
+      renderError(error.message, error.type);
+    } else {
+      renderError('Something went sideways. Try again?', 'network');
+    }
+  }
 }
 
 jokeBtn?.addEventListener('click', generateJoke);

--- a/projects/dad-jokes/refactored/src/ui.ts
+++ b/projects/dad-jokes/refactored/src/ui.ts
@@ -1,18 +1,41 @@
 /**
  * UI rendering functions.
  *
- * Security fix (#6): innerHTML replaced with textContent to prevent XSS.
- * The icanhazdadjoke API returns plain text jokes, so textContent is
- * both safer and more appropriate.
+ * All DOM updates go through this module.
+ * Uses textContent (not innerHTML) to prevent XSS.
  */
+
+/** Error message copy per DECISIONS.md D14 */
+const ERROR_MESSAGES: Record<string, string> = {
+  network: "Can't reach the joke factory. Check your connection and try again.",
+  http: 'The joke servers are having a bad day. Give it a sec.',
+  timeout: 'Request timed out — the joke servers might be slow.',
+  validation: 'Something went sideways. Try again?',
+};
 
 /**
  * Display a joke in the joke element.
- * Uses textContent (not innerHTML) to prevent XSS injection.
+ * Clears any error state.
  */
 export function renderJoke(jokeText: string): void {
   const jokeEl = document.getElementById('joke');
   if (jokeEl) {
     jokeEl.textContent = jokeText;
+    jokeEl.classList.remove('joke--error');
+  }
+}
+
+/**
+ * Display an error message in the joke element.
+ * Uses the copy from DECISIONS.md D14 based on error type.
+ */
+export function renderError(
+  message: string,
+  type: 'network' | 'http' | 'timeout' | 'validation',
+): void {
+  const jokeEl = document.getElementById('joke');
+  if (jokeEl) {
+    jokeEl.textContent = ERROR_MESSAGES[type] ?? message;
+    jokeEl.classList.add('joke--error');
   }
 }


### PR DESCRIPTION
## Summary
Complete overhaul of the API layer from zero error handling to production-grade resilience.

### What changed
- **`api.ts`**: Custom `ApiError` class, AbortController timeout, HTTP status checking, response validation, User-Agent header, request cancellation
- **`ui.ts`**: New `renderError()` with copy from DECISIONS.md D14, error type → message mapping
- **`main.ts`**: try/catch wrapping with typed error handling

### Error classification
| Type | Trigger | User message |
|------|---------|-------------|
| `network` | Offline, DNS failure | "Can't reach the joke factory..." |
| `http` | 4xx/5xx response | "The joke servers are having a bad day..." |
| `timeout` | >10s no response | "Request timed out..." |
| `validation` | Unexpected response shape | "Something went sideways..." |

## Test plan
- [x] All 7 baseline tests pass (happy path unchanged)
- [x] TypeScript compiles clean
- [ ] Manual test: disconnect network → error message shown
- [ ] Manual test: rapid clicking → only latest request renders

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)