### PR TITLE
Add Content Security Policy meta tag (#13)

### DIFF
--- a/projects/dad-jokes/refactored/index.html
+++ b/projects/dad-jokes/refactored/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; connect-src https://icanhazdadjoke.com; img-src 'self'; frame-src 'none'; base-uri 'self'; form-action 'none';"
+    />
     <title>Dad Jokes</title>
   </head>
   <body>

--- a/projects/dad-jokes/refactored/vite.config.ts
+++ b/projects/dad-jokes/refactored/vite.config.ts
@@ -1,7 +1,31 @@
 /// <reference types="vitest/config" />
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
+
+/**
+ * Relax CSP in dev mode so Vite's HMR inline scripts work.
+ * Production builds keep the strict CSP from index.html.
+ */
+function cspDevPlugin(): Plugin {
+  return {
+    name: 'csp-dev-relax',
+    transformIndexHtml(html, ctx) {
+      if (ctx.server) {
+        // Dev mode: allow inline scripts/styles for Vite HMR
+        return html.replace(
+          /script-src 'self'/,
+          "script-src 'self' 'unsafe-inline'",
+        ).replace(
+          /style-src 'self'/,
+          "style-src 'self' 'unsafe-inline'",
+        );
+      }
+      return html;
+    },
+  };
+}
 
 export default defineConfig({
+  plugins: [cspDevPlugin()],
   test: {
     environment: 'happy-dom',
     globals: true,


### PR DESCRIPTION
## Summary
- Adds strict CSP via `<meta>` tag in `index.html` per D13
- Simplified policy since fonts are self-hosted (@fontsource) — no Google Fonts domains needed
- Vite plugin (`cspDevPlugin`) relaxes CSP in dev mode to allow HMR inline scripts
- Production builds keep the strict policy with no `unsafe-inline`

## CSP Policy
| Directive | Value | Why |
|-----------|-------|-----|
| `default-src` | `'self'` | Baseline lockdown |
| `script-src` | `'self'` | No inline scripts — blocks XSS injection |
| `style-src` | `'self'` | Self-hosted fonts, no external CSS |
| `font-src` | `'self'` | @fontsource bundles fonts locally |
| `connect-src` | `https://icanhazdadjoke.com` | Only the joke API |
| `img-src` | `'self'` | Own images only |
| `frame-src` | `'none'` | No iframes |
| `base-uri` | `'self'` | Prevent base tag hijacking |
| `form-action` | `'none'` | No form submissions |

## Changes
| File | What changed |
|------|-------------|
| `index.html` | CSP meta tag added |
| `vite.config.ts` | `cspDevPlugin()` for dev mode CSP relaxation |

## Test plan
- [x] All 7 baseline tests pass
- [x] Production build contains strict CSP (verified in dist/index.html)
- [ ] Manual: `vite preview` — app loads with no CSP console errors
- [ ] Manual: `vite dev` — HMR works with relaxed CSP
- [ ] Manual: injecting `<script>` via DOM is blocked by CSP

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)