### PR TITLE
test(dad-jokes): Sprint 2 test gap-fill — 131 tests, 100% line coverage (#40)

### DIFF
--- a/projects/dad-jokes/refactored/src/test/api.gap.test.ts
+++ b/projects/dad-jokes/refactored/src/test/api.gap.test.ts
@@ -1,0 +1,67 @@
+/**
+ * API gap-fill tests — Ticket #40
+ *
+ * Covers two branches not reached by the main api.test.ts:
+ *
+ * 1. Timeout abort path (line 77): The setTimeout callback calls
+ *    activeController?.abort(). This requires fake timers to trigger
+ *    the timeout synchronously before the fetch completes.
+ *
+ * 2. Unknown error fallback (line 133): When fetch rejects with something
+ *    that is neither ApiError, DOMException(AbortError), nor TypeError,
+ *    the catch block wraps it as an ApiError with type 'network'.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from './mocks/server.ts';
+import { fetchJoke, ApiError } from '../api.ts';
+import { API_URL, REQUEST_TIMEOUT_MS } from '../constants.ts';
+
+describe('API client: timeout abort path', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('throws ApiError with type "timeout" when request times out', async () => {
+    // MSW handler that never responds (hangs until aborted)
+    server.use(
+      http.get(API_URL, async ({ request }) => {
+        // Wait for abort signal
+        await new Promise<void>((_, reject) => {
+          request.signal.addEventListener('abort', () =>
+            reject(new DOMException('AbortError', 'AbortError'))
+          );
+        });
+        return HttpResponse.json({});
+      }),
+    );
+
+    const promise = fetchJoke();
+
+    // Advance timers past the timeout to trigger the abort callback
+    vi.advanceTimersByTime(REQUEST_TIMEOUT_MS + 100);
+
+    await expect(promise).rejects.toMatchObject({
+      type: 'timeout',
+    });
+  });
+});
+
+describe('API client: unknown error fallback', () => {
+  it('throws ApiError with type "network" for unknown thrown errors', async () => {
+    // MSW swallows server-side errors, so we stub fetch directly to throw
+    // a non-TypeError, non-DOMException, non-ApiError — the catch-all branch.
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockRejectedValueOnce(new RangeError('Unexpected'));
+
+    await expect(fetchJoke()).rejects.toMatchObject({ type: 'network' });
+    await expect(fetchJoke()).rejects.toBeInstanceOf(ApiError);
+
+    globalThis.fetch = originalFetch;
+  });
+});

--- a/projects/dad-jokes/refactored/src/test/storage.test.ts
+++ b/projects/dad-jokes/refactored/src/test/storage.test.ts
@@ -1,11 +1,11 @@
 /**
- * Storage tests — Ticket #32
+ * Storage tests — Tickets #32 / #36
  *
- * Tests localStorage persistence for joke history.
+ * Tests localStorage persistence for joke history and favourites.
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { loadHistory, saveHistory } from '../storage.ts';
+import { loadHistory, saveHistory, loadFavourites, saveFavourites } from '../storage.ts';
 
 // Minimal localStorage mock
 const store: Record<string, string> = {};
@@ -21,6 +21,8 @@ beforeEach(() => {
   localStorageMock.clear();
   vi.clearAllMocks();
 });
+
+// ===== loadHistory =====
 
 describe('loadHistory', () => {
   it('returns [] when key does not exist', () => {
@@ -44,6 +46,8 @@ describe('loadHistory', () => {
   });
 });
 
+// ===== saveHistory =====
+
 describe('saveHistory', () => {
   it('persists jokes to localStorage', () => {
     const jokes = [{ id: 'x', joke: 'Joke X' }];
@@ -51,10 +55,62 @@ describe('saveHistory', () => {
     expect(store['dad-jokes-history-v1']).toBe(JSON.stringify(jokes));
   });
 
-  it('does not throw when localStorage is unavailable', () => {
+  it('does not throw when localStorage throws (quota exceeded)', () => {
     localStorageMock.setItem.mockImplementationOnce(() => {
       throw new DOMException('QuotaExceededError');
     });
     expect(() => saveHistory([{ id: 'y', joke: 'Y' }])).not.toThrow();
+  });
+});
+
+// ===== loadFavourites =====
+
+describe('loadFavourites', () => {
+  it('returns [] when key does not exist', () => {
+    expect(loadFavourites()).toEqual([]);
+  });
+
+  it('returns parsed array when valid JSON is stored', () => {
+    const jokes = [{ id: 'fav1', joke: 'Fav joke 1' }, { id: 'fav2', joke: 'Fav joke 2' }];
+    store['dad-jokes-favourites-v1'] = JSON.stringify(jokes);
+    expect(loadFavourites()).toEqual(jokes);
+  });
+
+  it('returns [] when stored value is invalid JSON', () => {
+    store['dad-jokes-favourites-v1'] = 'not-json{{{';
+    expect(loadFavourites()).toEqual([]);
+  });
+
+  it('returns [] when stored value is valid JSON but not an array', () => {
+    store['dad-jokes-favourites-v1'] = JSON.stringify({ id: 'f', joke: 'F' });
+    expect(loadFavourites()).toEqual([]);
+  });
+});
+
+// ===== saveFavourites =====
+
+describe('saveFavourites', () => {
+  it('persists favourites to localStorage', () => {
+    const jokes = [{ id: 'f1', joke: 'Favourite 1' }];
+    saveFavourites(jokes);
+    expect(store['dad-jokes-favourites-v1']).toBe(JSON.stringify(jokes));
+  });
+
+  it('does not throw when localStorage throws (quota exceeded)', () => {
+    localStorageMock.setItem.mockImplementationOnce(() => {
+      throw new DOMException('QuotaExceededError');
+    });
+    expect(() => saveFavourites([{ id: 'f2', joke: 'F2' }])).not.toThrow();
+  });
+
+  it('history and favourites use separate storage keys', () => {
+    const historyJokes = [{ id: 'h1', joke: 'History joke' }];
+    const favJokes = [{ id: 'f1', joke: 'Fav joke' }];
+
+    saveHistory(historyJokes);
+    saveFavourites(favJokes);
+
+    expect(loadHistory()).toEqual(historyJokes);
+    expect(loadFavourites()).toEqual(favJokes);
   });
 });

--- a/projects/dad-jokes/refactored/src/test/ui.test.ts
+++ b/projects/dad-jokes/refactored/src/test/ui.test.ts
@@ -59,6 +59,11 @@ function setupDOM(): void {
 describe('UI: renderJoke()', () => {
   beforeEach(setupDOM);
 
+  it('does not throw when joke element is missing', () => {
+    document.getElementById('joke')?.remove();
+    expect(() => renderJoke('test')).not.toThrow();
+  });
+
   it('sets joke text via textContent', () => {
     renderJoke('Why did the bike fall over? It was two-tired.');
     const jokeEl = document.getElementById('joke');
@@ -151,6 +156,18 @@ describe('UI: renderError()', () => {
     expect(handler).toHaveBeenCalledOnce();
   });
 
+  it('retry button click does not throw when no handler is registered', () => {
+    // Clear any previously registered handler
+    setRetryHandler(() => {});
+    setRetryHandler(null as unknown as () => void);
+
+    renderError('error', 'network');
+    const retryBtn = document
+      .getElementById('joke')
+      ?.querySelector('.retry-btn') as HTMLButtonElement;
+    expect(() => retryBtn.click()).not.toThrow();
+  });
+
   it('adds joke--error class', () => {
     renderError('error', 'network');
     const jokeEl = document.getElementById('joke');
@@ -192,10 +209,25 @@ describe('UI: renderError()', () => {
       'joke factory',
     );
   });
+
+  it('does not throw when joke element is missing', () => {
+    document.getElementById('joke')?.remove();
+    expect(() => renderError('error', 'network')).not.toThrow();
+  });
 });
 
 describe('UI: showLoading()', () => {
   beforeEach(setupDOM);
+
+  it('does not throw when joke element is missing', () => {
+    document.getElementById('joke')?.remove();
+    expect(() => showLoading(false)).not.toThrow();
+  });
+
+  it('does not throw when jokeBtn element is missing', () => {
+    document.getElementById('jokeBtn')?.remove();
+    expect(() => showLoading(false)).not.toThrow();
+  });
 
   it('sets aria-busy to "true" on joke element', () => {
     showLoading(false);
@@ -239,6 +271,16 @@ describe('UI: showLoading()', () => {
 describe('UI: hideLoading()', () => {
   beforeEach(setupDOM);
 
+  it('does not throw when joke element is missing', () => {
+    document.getElementById('joke')?.remove();
+    expect(() => hideLoading()).not.toThrow();
+  });
+
+  it('does not throw when jokeBtn element is missing', () => {
+    document.getElementById('jokeBtn')?.remove();
+    expect(() => hideLoading()).not.toThrow();
+  });
+
   it('sets aria-busy to "false"', () => {
     showLoading(false);
     hideLoading();
@@ -263,6 +305,13 @@ describe('UI: hideLoading()', () => {
 
 describe('UI: renderHistoryNav()', () => {
   beforeEach(setupDOM);
+
+  it('does not throw when nav elements are missing', () => {
+    document.getElementById('prevBtn')?.remove();
+    document.getElementById('nextBtn')?.remove();
+    document.querySelector('.history-counter')?.remove();
+    expect(() => renderHistoryNav(0, 5)).not.toThrow();
+  });
 
   it('disables prevBtn when at oldest joke (index === total - 1)', () => {
     renderHistoryNav(4, 5);
@@ -428,10 +477,21 @@ describe('UI: updateFavouritesCount()', () => {
     updateFavouritesCount(5);
     expect(document.getElementById('favCount')?.textContent).toBe('5');
   });
+
+  it('does not throw when favCount element is missing', () => {
+    document.getElementById('favCount')?.remove();
+    expect(() => updateFavouritesCount(3)).not.toThrow();
+  });
 });
 
 describe('UI: toggleFavouritesPanel()', () => {
   beforeEach(setupDOM);
+
+  it('does not throw when panel and button are missing', () => {
+    document.getElementById('favPanel')?.remove();
+    document.getElementById('favListBtn')?.remove();
+    expect(() => toggleFavouritesPanel(true)).not.toThrow();
+  });
 
   it('shows panel when open=true', () => {
     toggleFavouritesPanel(true);
@@ -479,5 +539,10 @@ describe('UI: renderFavouritesList()', () => {
     const text = document.querySelector('.fav-item__text');
     expect(text?.textContent).toBe('<script>alert(1)</script>');
     expect(document.querySelector('script')).toBeNull();
+  });
+
+  it('does nothing if favPanel element is missing', () => {
+    document.getElementById('favPanel')?.remove();
+    expect(() => renderFavouritesList([{ id: 'a', joke: 'A' }], vi.fn())).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Final test pass after all Sprint 2 features are integrated. Fills coverage gaps identified by running `vitest --coverage` on the merged codebase.

Closes #40

## What was added

**`storage.test.ts`** (expanded from 6 → 13 tests):
- `loadFavourites` / `saveFavourites` — previously completely untested
- Quota-exceeded (QuotaExceededError) path for `saveFavourites`
- Key isolation test confirming history and favourites use separate storage keys

**`api.gap.test.ts`** (new, 2 tests):
- **Timeout abort path** (api.ts line 77): Uses fake timers to advance past `REQUEST_TIMEOUT_MS`, triggering the `setTimeout(() => activeController?.abort())` callback directly
- **Unknown error fallback** (api.ts line 133): Stubs `globalThis.fetch` to throw a `RangeError` (not TypeError/DOMException/ApiError), confirming the catch-all wraps it as `type: 'network'`

**`ui.test.ts`** (expanded from 56 → 65 tests):
- Null-guard coverage for every DOM-dependent function when elements are missing: `renderJoke`, `renderError`, `showLoading` (×2), `hideLoading` (×2), `renderHistoryNav`, `updateFavouritesCount`, `toggleFavouritesPanel`, `renderFavouritesList`
- Retry button click when `retryHandler` is null (the `if (retryHandler) retryHandler()` branch)

## Coverage results

```
File        | % Stmts | % Branch | % Funcs | % Lines
------------|---------|----------|---------|--------
api.ts      |   100   |   100    |   100   |   100
constants.ts|   100   |   100    |   100   |   100
state.ts    |   100   |   100    |   100   |   100
storage.ts  |   100   |   100    |   100   |   100
ui.ts       |   100   |   94.44  |   100   |   100
```

Remaining 5.56% branch gap in `ui.ts`: two no-op null guards (`if (btn)` in `setCopyButtonEnabled`/`setShareButtonEnabled`) and the `?? message` nullish coalescing fallback in `renderError` which is unreachable because we always pass a valid error type key. Not worth testing.

## Test count

- Sprint 1 baseline: 55 tests
- After Sprint 2 features: 111 tests
- After this gap-fill: **131 tests**, 0 failures

## No manual testing required

Test-only ticket — no behaviour changed.