### PR TITLE
process: Sprint 2 learnings — plan review, parallel-safe label, per-ticket merge model

### DIFF
--- a/.claude/commands/sprint-plan-review.md
+++ b/.claude/commands/sprint-plan-review.md
@@ -1,0 +1,102 @@
+You are a UX Designer and QA Engineer reviewing a sprint plan before execution begins.
+
+Given "$ARGUMENTS" (format: "project-name phase-number", e.g. "dad-jokes 3"), do the following:
+
+## Purpose
+
+Sprint planning creates tickets. But tickets for UI features often leave interaction design decisions implicit — left for the executing agent to figure out at runtime. This command surfaces those decisions BEFORE code is written, when changing them costs nothing.
+
+Run this after `/sprint-plan` and before `/sprint-run` for any sprint that includes:
+- New UI surfaces (panels, modals, drawers, tabs)
+- New interactive elements (buttons, inputs, toggles, counters)
+- State changes visible to the user (transitions, feedback, empty states)
+- Accessibility requirements for new components
+- Any ticket labelled `feature` that the UX or QA agents should weigh in on
+
+## Inputs
+
+1. Read the sprint plan: `projects/{project-name}/sprints/phase-{n}-plan.md`
+2. Read all open tickets for this sprint: `gh issue list --label phase-{n} --state open`
+3. Read the DECISIONS.md for UX direction and constraints
+4. Read the existing app code in `projects/{project-name}/refactored/src/` to understand the current patterns
+
+## UX Review
+
+Adopt the perspective of a UX Designer. For each ticket that involves user-visible changes:
+
+**Ask these questions for each feature ticket:**
+- What does the user see before this feature is used? After? On error?
+- Is there an empty state that needs designing?
+- What interaction model are we choosing, and is it consistent with the rest of the app?
+- Are icon-only buttons being used? If so, do they have visible labels or clear affordance?
+- Are transitions needed, or is an abrupt state change acceptable?
+- Is there a counter, badge, or position indicator? Where does it live in the layout?
+- Does this feature have a discoverable entry point, or will users miss it?
+
+**For each decision, write:**
+1. The implicit assumption the ticket currently makes
+2. The options available (keep it brief — 2-3 options max)
+3. The recommended approach and why
+4. The exact acceptance criteria addition or ticket note to add
+
+## QA Review
+
+Adopt the perspective of a QA Engineer. For each ticket:
+
+**Ask these questions:**
+- What are the edge cases? (empty state, max capacity, API error, offline)
+- What are the boundary conditions? (max 100 favourites — what happens at 101? what happens at 0?)
+- Which tickets touch the same files and could produce merge conflicts if run in parallel?
+- Are there interactions between features that need an integration test, not just unit tests?
+- Is the `parallel-safe` label applied correctly? Flag any that look wrong.
+
+## Output
+
+### Summary
+One paragraph: what this sprint is trying to achieve, and the 2-3 biggest UX/QA risks going in.
+
+### Ticket-by-ticket findings
+
+For each ticket with a finding:
+
+```
+## #42 — [Ticket title]
+
+**UX finding:** [What's implicit that should be explicit]
+**Recommendation:** [What to do]
+**Action:** Update ticket #42 with: [exact text to add to the ticket body]
+```
+
+### Parallel-safe audit
+
+List which tickets are correctly labelled `parallel-safe` and flag any that should be added or removed:
+- ✅ #30 `parallel-safe` — correct (only touches analytics.ts, no shared files)
+- ⚠️ #38 `parallel-safe` — should be removed (touches ui.ts which #34 also modifies)
+
+### Decision log
+
+A short list of the design decisions made during this review, formatted for the DECISIONS.md addendum:
+
+| Decision | Options considered | Chosen | Rationale |
+|----------|-------------------|--------|-----------|
+| ... | ... | ... | ... |
+
+## Apply findings
+
+After producing the review:
+
+1. For each ticket with an "Action" item, update the GitHub issue body to add the UX/QA notes:
+   ```
+   gh issue edit {number} --body "$(gh issue view {number} --json body -q '.body')\n\n---\n\n**UX notes (from plan review):**\n{notes}"
+   ```
+
+2. Add or remove `parallel-safe` labels as needed:
+   ```
+   gh issue edit {number} --add-label parallel-safe
+   gh issue edit {number} --remove-label parallel-safe
+   ```
+
+3. Write a summary of findings to `projects/{project-name}/sprints/phase-{n}-plan-review.md`
+
+4. Tell the user:
+   > Plan review complete. {X} tickets updated with UX/QA notes. Run `/sprint-run {project-name} {n}` to begin execution.

--- a/.claude/commands/sprint-plan.md
+++ b/.claude/commands/sprint-plan.md
@@ -64,6 +64,7 @@ Tracking is done entirely with **GitHub Issues + labels + milestones** — which
 - Which expert agent is best suited to work on it (e.g. "frontend", "backend", "qa")
 - Estimated complexity (S/M/L)
 - Dependencies (which tickets need to be done first)
+- **`parallel-safe` label** if the ticket touches entirely different files from all other open tickets (e.g. different module, different CSS section, no shared state). Do NOT mark parallel-safe if there's any chance of file overlap — when in doubt, omit it
 
 **Watch for ghost tickets:** If a ticket's work will obviously be absorbed into another (e.g. a migration ticket whose scope is fully covered by the scaffold ticket), flag it explicitly in the plan rather than creating a separate issue that will produce an empty PR. Either merge the tickets or note upfront: "This will be done as part of #{other-ticket}, no separate PR needed."
 
@@ -84,6 +85,7 @@ gh label create bug --color D73A4A
 gh label create test --color BFD4F2
 gh label create docs --color 0075CA
 gh label create phase-1 --color C5DEF5
+gh label create parallel-safe --description "Can run concurrently in separate sessions — touches no shared files" --color 0E8A16
 ```
 (Adjust phase label number as needed. Skip any that already exist.)
 
@@ -119,3 +121,9 @@ Write the full sprint plan to `projects/{project-name}/sprints/phase-{n}-plan.md
 - Anything explicitly pushed to a future sprint and why
 
 Prioritise ruthlessly. Not everything from the phase plan needs to happen — focus on what delivers the most value. Flag anything you'd push to the next sprint.
+
+## After planning
+
+At the end of the plan output, remind the user:
+
+> **Next step:** If this sprint includes new UI surfaces or interaction patterns, run `/sprint-plan-review {project-name} {n}` before executing. This gives UX and QA specialists a chance to surface implicit design decisions before any code is written. Then run `/sprint-run {project-name} {n}` to start execution.

--- a/.claude/commands/sprint-resume.md
+++ b/.claude/commands/sprint-resume.md
@@ -14,43 +14,39 @@ Check the current state of the sprint before doing anything:
    - **Awaiting merge** — PR open, not yet merged
    - **Not started** — issue open, no PR
 
-**If any "awaiting merge" PRs exist, STOP.** The user hasn't finished merging the previous wave yet. Tell them:
+**If any "awaiting merge" PRs exist, STOP.** The user hasn't merged the previous ticket yet. Tell them:
 
 ```
-There are still open PRs from the previous wave that need to be merged before I can continue:
-  #12 — [title]
-  #14 — [title]
+There's still an open PR that needs to be merged before I can continue:
+  #{number} — [title]
 
-Merge these first (in dependency order if applicable), then re-run /sprint-resume.
+Merge it, then re-run /sprint-resume.
 ```
 
-## Identify the next wave
+## Identify the next ticket
 
-Once all previous wave PRs are confirmed merged, figure out which tickets are now unblocked:
+Once the previous PR is confirmed merged, figure out which ticket to build next.
 
-A ticket is ready to build if:
+A ticket is ready if:
 - It has no `Blocked by:` references, OR
 - Every issue listed in its `Blocked by:` is now closed/merged
 
-Group the ready tickets into the next wave. If nothing is unblocked, the sprint is complete — skip to the wrap-up section.
+From the ready tickets, pick the **smallest complexity first** (S before M before L). If multiple tickets are the same size and both `parallel-safe`, mention this to the user (see below).
 
 Show the user what's about to happen:
 ```
-Resuming Sprint {n} — Wave {current wave number}
+Resuming Sprint {n} — ticket {X} of {total}
 
-Building now: #15, #16
-Still waiting (will be Wave {n+1}): #17 (depends on #15)
+Building now: #{next} — [title]
+After that: #{following} — [title] (if applicable)
+Remaining after this merge: {X} tickets
 ```
 
-## Execute the next wave
+## Execute the next ticket
 
-Work through every ticket in this wave, one at a time. Smallest complexity first within the wave.
+**1. Read it** — `gh issue view {issue-number}`. Note the acceptance criteria, any UX notes added by `/sprint-plan-review`, and the expert agent role tagged — adopt that specialist perspective.
 
-For each ticket:
-
-**1. Read it** — `gh issue view {issue-number}`. Note the acceptance criteria and the expert agent role tagged — adopt that specialist perspective.
-
-**2. Branch** — `git checkout main && git pull`, then `git checkout -b {issue-number}-{short-description}`. Confirm with `git log --oneline -3` that the merged work from the previous wave is present on `main` before starting.
+**2. Branch** — `git checkout main && git pull`, then `git checkout -b {issue-number}-{short-description}`. Confirm with `git log --oneline -3` that the merged work from previous tickets is present on `main`.
 
 **3. Pre-flight** — Run the full test suite before touching anything. If tests fail, flag it and stop.
 
@@ -60,31 +56,33 @@ For each ticket:
 
 **6. PR** — Update `CHANGELOG.md`, then `gh pr create --base main` referencing the issue ("Closes #{issue-number}"). Include what was done, why, key trade-offs, and what needs manual testing.
 
-**7. Continue** — Do NOT merge. `git checkout main` and move to the next ticket in this wave.
+**7. Stop** — Hand off to the user. Do NOT start the next ticket.
 
-## Hand off after this wave
-
-When all tickets in this wave have open PRs:
+## Hand off after this ticket
 
 ```
-Wave {n} complete — {X} PRs ready for review.
+PR ready: #{number} — [title]
 
-Please review and merge in this order:
-1. #15 — [title] (independent)
-2. #16 — [title] (depends on #15, merge after)
-
-Then run:
-  /sprint-resume {project-name} {phase}    ← if more waves remain
-  /sprint-review {project-name} {phase}    ← if this was the final wave
+Please review and merge, then run:
+  /sprint-resume {project-name} {phase}    ← {X} tickets remaining
+  /sprint-review {project-name} {phase}    ← if this was the last one
 ```
 
-Be explicit about which is applicable — don't make the user guess whether they're done.
+Be explicit about which applies. If this is the final ticket, say so clearly.
 
-## Sprint wrap-up (final wave only)
+**If the next two tickets are both `parallel-safe`**, also offer:
+
+```
+Next up: #{A} and #{B} are both parallel-safe — they touch entirely different files.
+You can run them in parallel: open a second terminal and run /work-ticket {project-name} {B}
+while this session handles #{A}. Merge both before continuing.
+```
+
+## Sprint wrap-up (final ticket only)
 
 When all issues are closed and all PRs merged, write the full execution summary to `projects/{project-name}/sprints/phase-{n}-execution-log.md`:
 
-- All tickets worked, PR numbers, which wave each belonged to
+- All tickets worked, PR numbers, order executed
 - Any blockers hit and how they were resolved
 - Any scope discoveries noted during implementation
 - Any tests updated and why

--- a/.claude/commands/sprint-run.md
+++ b/.claude/commands/sprint-run.md
@@ -10,27 +10,34 @@ Given "$ARGUMENTS" (format: "project-name phase-number", e.g. "dad-jokes 1"), do
 4. Verify baseline tests exist. **If they don't, STOP and tell the user to run `/write-baseline-tests` first.**
 5. Check for existing PRs: `gh pr list --state open`. If open PRs already exist for this sprint's issues, **STOP and tell the user this sprint has already been started — use `/sprint-resume` to continue.**
 
-## Map the full wave plan
+## Map the full execution plan
 
 Before touching any code, analyse all tickets and group them into dependency tiers based on their `Blocked by:` references. Show the user the full picture upfront:
 
 ```
-Sprint {n} wave plan:
+Sprint {n} execution plan:
 
-Wave 1 (building now): #12, #13, #14
-Wave 2 (needs Wave 1 merged first): #15, #16
-Wave 3 (needs Wave 2 merged first): #17
+Tier 1 (no blockers): #12, #13, #14
+Tier 2 (needs Tier 1 merged first): #15, #16
+Tier 3 (needs Tier 2 merged first): #17
+
+Execution model: one ticket at a time, stop for merge after each PR.
+Total merge checkpoints: ~{total tickets}
 ```
 
-This is important — the user needs to understand there will be merge checkpoints before the sprint is complete.
+This is important — the user needs to understand the cadence. Each ticket gets its own merge checkpoint.
 
-## Execute Wave 1
+**Note on parallel-safe tickets:** If two or more tickets in the same tier are labelled `parallel-safe`, tell the user they can run those tickets in separate terminal sessions simultaneously using `/work-ticket`. All parallel-safe tickets in a tier must be merged before starting the next tier.
 
-Work through every Wave 1 ticket (tickets with no blockers) one at a time. Within the wave, tackle smallest complexity first.
+## Execute the first ticket
+
+Work through tickets one at a time, starting with the first ticket in Tier 1. Within a tier, tackle smallest complexity first.
+
+**Why one at a time?** Multiple open PRs touching the same files cause merge conflicts. The per-ticket merge model eliminates this entirely — each branch always cuts from a current `main`.
 
 For each ticket:
 
-**1. Read it** — `gh issue view {issue-number}`. Note the acceptance criteria and the expert agent role tagged on it — adopt that specialist perspective.
+**1. Read it** — `gh issue view {issue-number}`. Note the acceptance criteria, UX notes (added by `/sprint-plan-review`), and the expert agent role tagged on it — adopt that specialist perspective.
 
 **2. Branch** — `git checkout main && git pull`, then `git checkout -b {issue-number}-{short-description}`. Confirm with `git log --oneline -3` that your base is what you expect.
 
@@ -42,24 +49,26 @@ For each ticket:
 
 **6. PR** — Update `CHANGELOG.md`, then `gh pr create --base main` referencing the issue ("Closes #{issue-number}"). Include what was done, why, key trade-offs, and what needs manual testing.
 
-**7. Continue** — Do NOT merge. `git checkout main` and move to the next Wave 1 ticket.
+**7. Stop** — Hand off to the user for this ticket. Do NOT move to the next ticket.
 
-## Hand off
+## Hand off after each ticket
 
-When all Wave 1 tickets have open PRs, stop and hand off to the user:
+After each ticket's PR is opened, stop and hand off:
 
 ```
-Wave 1 complete — {X} PRs ready for review.
+PR ready: #{issue-number} — [title]
 
-Please review and merge in this order:
-1. #12 — [title] (independent, merge in any order)
-2. #13 — [title] (independent, merge in any order)
-3. #14 — [title] (independent, merge in any order)
-
-Once all Wave 1 PRs are merged, run:
+Please review and merge this PR, then run:
   /sprint-resume {project-name} {n}
 
-Wave 2 will then build:
-  #15 — [title] (depends on #12, #13)
-  #16 — [title] (depends on #13)
+Next up: #{next-issue} — [title]
+Remaining: {X} tickets
+```
+
+If two or more tickets in the current tier are `parallel-safe`, you may offer:
+
+```
+Alternatively, #13 and #14 are both parallel-safe — they touch entirely different files.
+You can run /work-ticket {project-name} 13 and /work-ticket {project-name} 14 in separate
+terminal sessions simultaneously, then merge both before continuing.
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,9 @@ We use GitHub Issues, branches, and PRs to manage work — just like a real team
 | Command | Purpose |
 |---------|---------|
 | `/sprint-plan` | Break a phase into a sprint — reads DECISIONS.md Sprint Brief, creates epic, user stories, and tasks as GitHub issues |
-| `/sprint-run` | Start a sprint — maps all tickets into dependency waves, executes Wave 1, then stops for merges |
-| `/sprint-resume` | Continue a sprint after merging — detects where you are, executes the next wave, stops again. Repeat until done |
+| `/sprint-plan-review` | Specialist review of a sprint plan before execution — UX and QA agents review the proposed tickets, surface implicit design decisions, and write them into ticket descriptions. Run this after `/sprint-plan` and before `/sprint-run` for any sprint with new UI surfaces |
+| `/sprint-run` | Start a sprint — maps all tickets into dependency tiers, executes one ticket at a time, stops for a merge after each PR. Repeat with `/sprint-resume` until done |
+| `/sprint-resume` | Continue a sprint after merging — picks up the next unstarted ticket, executes it, stops for merge. Repeat until all tickets are done |
 | `/work-ticket` | Pick up a single ticket manually — creates branch, does the work, commits, opens a PR. Use this if you want to cherry-pick one ticket rather than run the whole sprint |
 | `/sprint-review` | End-of-sprint review and retro — what shipped, what didn't, what we learned, reprioritise for next sprint |
 
@@ -71,13 +72,14 @@ Commands for turning project work into blog posts and videos. Note: `/content-ex
 3. **Decisions** — Synthesise reviews into concrete decisions and a Sprint Brief (`/product-decisions`). This is where scope gets set and disagreements get resolved
 4. **Baseline tests** — Write tests that lock down the current behaviour BEFORE changing anything (`/write-baseline-tests`). Prerequisite for all refactoring
 5. **Sprint plan** — Break the Sprint Brief into tickets on GitHub (`/sprint-plan`). Only plans work that's in scope per DECISIONS.md
-6. **Build** — Start with `/sprint-run`, which maps all tickets into waves and builds Wave 1. Merge those PRs, then `/sprint-resume` to build the next wave. Repeat until all waves are done. Or use `/work-ticket` to handle a single ticket manually. Tests must pass before any PR is opened
-7. **Sprint review** — Review what shipped, retro, reprioritise (`/sprint-review`). Feed learnings back into decisions for next sprint
-8. **Log** — Capture the session for content (`/session-log`)
-9. **Content** — Plan and produce blog/video content (`/content-plan`, `/content-review`)
-10. **Next** — Figure out what's next (`/content-next`, then back to step 3 for next sprint — decisions may change based on what we learned)
-11. **Project retrospective** — When the project is done, run `/project-retrospective` for a full review of outcomes, agent performance, and process improvements
-12. **Extract learnings** — Run `/content-extract` to identify teachable moments for the blog/video series
+6. **Plan review** — For sprints with new UI surfaces or interaction patterns, run `/sprint-plan-review` to get specialist (UX, QA) eyes on the plan before any code is written. Implicit design decisions get made explicit and written into ticket descriptions
+7. **Build** — Run `/sprint-run`, which executes one ticket at a time and stops for a merge after each PR. Run `/sprint-resume` after each merge to continue. Or use `/work-ticket` to handle a single ticket manually. Tests must pass before any PR is opened
+8. **Sprint review** — Review what shipped, retro, reprioritise (`/sprint-review`). Feed learnings back into decisions for next sprint
+9. **Log** — Capture the session for content (`/session-log`)
+10. **Content** — Plan and produce blog/video content (`/content-plan`, `/content-review`)
+11. **Next** — Figure out what's next (`/content-next`, then back to step 3 for next sprint — decisions may change based on what we learned)
+12. **Project retrospective** — When the project is done, run `/project-retrospective` for a full review of outcomes, agent performance, and process improvements
+13. **Extract learnings** — Run `/content-extract` to identify teachable moments for the blog/video series
 
 ### Code standards
 - Accessibility is not optional — WCAG AA minimum
@@ -90,9 +92,15 @@ Commands for turning project work into blog posts and videos. Note: `/content-ex
 ### GitHub workflow
 - Repo lives on JCrocker4679 account
 - All work happens on feature branches, never directly on main
-- One branch per ticket, one PR per ticket
+- One branch per ticket, one PR per ticket — each branch cuts from `main` after the previous PR is merged
 - PRs reference their issue ("Closes #12")
 - Claude Code creates issues, branches, and PRs via `gh` CLI — Joe reviews and merges
+- **Merge before continuing:** After each PR is opened, stop and wait for Joe to merge before starting the next ticket. This prevents merge conflicts from multiple branches touching the same files
+
+### Ticket parallelism
+Some tickets are `parallel-safe` — they touch entirely different files and can run in separate terminal sessions simultaneously. These are labelled `parallel-safe` in GitHub. To run them in parallel: open two Claude Code sessions and run `/work-ticket` on one ticket in each session. Merge both PRs before starting any ticket that depends on either.
+
+Tickets are NOT parallel-safe if they touch the same files (e.g. both modify `ui.ts` or `style.css`). When in doubt, run sequentially.
 
 ### Capturing learnings
 After each significant piece of work, update:

--- a/projects/dad-jokes/REVIEW.md
+++ b/projects/dad-jokes/REVIEW.md
@@ -92,21 +92,21 @@ All 14 tickets shipped. See `sprints/sprint-1-review.md` for full retro.
 11. ✅ Bonus: Content Security Policy
 12. ✅ Bonus: Vercel deployment config with security headers
 
-### Phase 2 — Make it useful 📋 NEXT (Sprint 2)
-Revised based on Sprint 1 learnings. Priority order:
+### Phase 2 — Make it useful ✅ COMPLETE (Sprint 2, 2026-02-23)
+All 12 tickets shipped. See `sprints/phase-2-review.md` for full retro.
 
-1. OG image (PNG 1200×630) — small thing, high polish impact *(carry-over from Sprint 1)*
-2. Joke history — localStorage array, back/forward navigation
-3. Copy to clipboard — Clipboard API
-4. Favourites — star/unstar with localStorage persistence
-5. Favourites list view
-6. Web Share API with clipboard fallback
-7. Search by keyword — uses API's search endpoint
-8. Analytics events — Vercel Analytics (joke_fetched, error, retry, favourite_added)
-9. Visual refresh — new colour palette (keep structure, update feel)
-10. E2E test: happy path with Playwright
+1. ✅ OG image (PNG 1200×630) — carry-over from Sprint 1
+2. ✅ Joke history — localStorage array, back/forward navigation, position counter
+3. ✅ Copy to clipboard — Clipboard API with 2s feedback
+4. ✅ Favourites — star/unstar with localStorage persistence (max 100)
+5. ✅ Favourites list view — browse and delete; live count badge; empty state
+6. ✅ Web Share API with clipboard fallback
+7. ✅ Analytics events — 8 typed events, `safeTrack()` wrapper
+8. ✅ Visual refresh — warm amber/cream palette, action row, icon buttons, crossfade
+9. ✅ Tests — 131 tests, 100% line coverage
+10. ✅ Deployed and verified live
 
-**Dropped from original Phase 2:** "Responsive design polish" — already done in Sprint 1.
+**Dropped from original Phase 2:** "Search by keyword" (pushed to Sprint 3), "E2E tests with Playwright" (pushed to Sprint 3).
 
 ### Phase 3 — Make it impressive 🔮 FUTURE
 *Sequencing revised — build tooling, tests, and deploy moved to Sprint 1 where they belonged.*
@@ -128,6 +128,8 @@ Revised based on Sprint 1 learnings. Priority order:
 | Claude Opus 4.6 | 8 expert agent reviews + decisions | Full team-review + product-decisions workflow |
 | Claude Opus 4.6 | Sprint 1 planning (15 issues) | /sprint-plan — accurate, well-sequenced |
 | Claude Opus 4.6 | Sprint 1 execution (13 PRs) | /sprint-run — autonomous, 14/14 tickets completed |
+| Claude Sonnet 4.6 | Sprint 2 planning (12 issues) | /sprint-plan — clean dependency graph, well-scoped |
+| Claude Sonnet 4.6 | Sprint 2 execution (12 PRs) | /sprint-run → manual conflict resolution → /sprint-resume — 12/12 tickets completed |
 
 ## Learnings
 
@@ -141,3 +143,10 @@ Revised based on Sprint 1 learnings. Priority order:
 - CSS custom properties + clamp() + focus-visible + prefers-reduced-motion should be defaults in all projects going forward.
 - The AI naturally wrote for Sprint 2 (CSS custom properties as theming groundwork) without being told to. This is the right instinct.
 - Context loss between sessions is the primary operational risk for long sprint-runs. Mitigate with branch checkpointing.
+
+**Sprint 2 (2026-02-23):**
+- Autonomous sprint-run without mid-wave merges causes merge conflicts when multiple tickets touch the same files (ui.ts, style.css). Fix: stop after each ticket, merge, continue.
+- Sprint planning has no specialist review step — UX decisions in ticket descriptions get made implicitly by the executing agent, not a specialist. Worth adding a UX review pass between /sprint-plan and /sprint-run.
+- Truly independent tickets (different files, no shared state) could run in parallel sub-agents — but current tooling makes this a manual orchestration step (two terminal sessions), not automated.
+- `safeTrack()` wrapper for analytics and typed event maps are patterns worth templating for all future projects.
+- CSS custom properties investment in Sprint 1 paid off in Sprint 2 — dark mode in Sprint 3 will be similarly cheap because of Sprint 2's palette work.

--- a/projects/dad-jokes/sprints/phase-2-review.md
+++ b/projects/dad-jokes/sprints/phase-2-review.md
@@ -1,0 +1,247 @@
+# Sprint 2 Review & Retrospective — Dad Jokes
+
+**Sprint:** 2 of 3 — Make it Useful
+**Date:** 2026-02-23
+**Facilitator:** Claude Code (Scrum Master)
+**Attendees:** Joe Crocker
+
+---
+
+## Sprint Goal
+
+> **Make the app worth coming back to — add joke history, favourites, copy, and share so users can do something with jokes, not just read them. Ship with a visual refresh that makes it feel like a real product.**
+
+**Verdict: ✅ Goal Met — all tickets shipped, deployed, and verified**
+
+12 of 12 work tickets shipped. 12 PRs merged to `main`. 131 tests passing (up from 55), 100% line coverage. App live at `dad-jokes-revisited.vercel.app`.
+
+---
+
+## Sprint Review — What We Delivered
+
+### Ticket-by-Ticket
+
+| # | Title | Status | PR | Notes |
+|---|-------|--------|----|-------|
+| #30 | Spike: Web Share + Clipboard API | ✅ Done | #42 | Findings doc produced; informed #34 and #35 |
+| #31 | Fix OG image (PNG 1200×630) | ✅ Done | #43 | Carry-over from Sprint 1; quick win |
+| #39 | Analytics events | ✅ Done | #44 | 8 typed events; `safeTrack()` wrapper |
+| #32 | Joke history: data layer | ✅ Done | #45 | localStorage, last 50 jokes, persists across reloads |
+| #36 | Favourites: star/unstar + localStorage | ✅ Done | #46 | Max 100 favourites, `aria-pressed` on star button |
+| #38 | Visual refresh | ✅ Done | #47 | Warm amber/cream palette, action row, icon buttons |
+| #34 | Copy to clipboard | ✅ Done | #48 | 2s "✓ Copied!" feedback, `execCommand` fallback |
+| #33 | History nav UI (back/forward) | ✅ Done | #49 | Position counter "2 / 8" |
+| #35 | Web Share API + clipboard fallback | ✅ Done | #50 | Native share on mobile, clipboard on desktop |
+| #37 | Favourites list view | ✅ Done | #51 | Browse + delete; live count badge; empty state |
+| #40 | Tests: gap-fill + coverage check | ✅ Done | #52 | 131 tests, 100% line coverage |
+| #41 | Deploy + verify | ✅ Done | #53 | CHANGELOG cleaned; live URL confirmed working |
+
+**12/12 tickets complete. 0 carry-over.**
+
+### Definition of Done — Checklist
+
+- [x] Joke history stored in localStorage (last 50 jokes)
+- [x] Back/forward navigation through history
+- [x] Copy joke to clipboard — single click, feedback on success
+- [x] Web Share API on mobile, clipboard fallback on desktop
+- [x] Favourites — star/unstar a joke, persisted to localStorage
+- [x] Favourites list view — see and delete saved favourites
+- [x] Visual refresh — warm amber palette, action row, button copy
+- [x] OG image PNG (1200×630) replacing placeholder SVG
+- [x] Analytics events wired (8 typed events)
+- [x] All tests passing, 100% line coverage
+- [x] Deployed to Vercel and confirmed working
+- [x] CHANGELOG.md up to date
+
+### What the App Can Do Now
+
+Before Sprint 2: fetch a joke, see an error if the API fails.
+
+After Sprint 2:
+- **Browse jokes over time** — back/forward through the last 50 jokes seen, position-tracked ("2 / 8"), history persists on reload
+- **Save favourites** — star any joke, up to 100 saved, with a browsable list view and per-joke delete
+- **Copy a joke** — one click, 2-second confirmation, works on all browsers
+- **Share a joke** — native share sheet on iOS/Android; clipboard on desktop
+- **Feels designed** — warm amber/cream palette, icon buttons in an action row, crossfade animation on new jokes
+- **Tracked** — 8 analytics events for every meaningful interaction, safely wrapped so failures are silent
+
+### Metrics
+
+| Metric | Sprint 1 | Sprint 2 | Delta |
+|--------|----------|----------|-------|
+| Source files | 7 | 8 (+`analytics.ts`) | +1 |
+| Source lines (non-test) | ~600 | ~900 | +300 |
+| Test lines | ~700 | 1,262 | +562 |
+| Tests | 55 | 131 | +76 |
+| Coverage | 97% | 100% | +3% |
+| Issues closed | 13 | 12 | — |
+| PRs merged | 13 | 12 | — |
+
+---
+
+## Retrospective
+
+### What Went Well
+
+**1. The pipeline held up for a larger sprint.**
+Sprint 1 proved the workflow. Sprint 2 confirmed it scales. 12 tickets, substantial new state management, a new module (`analytics.ts`), a visual rethink — all shipped cleanly with zero rework.
+
+**2. The spike genuinely earned its place.**
+`#30` (Web Share + Clipboard spike) was the first ticket in the execution order. The findings document it produced directly shaped how `#34` and `#35` were built — particularly the fallback strategy and the dismissed-share-sheet edge case. The pattern works: spike first, build second.
+
+**3. Analytics module design was smart.**
+The `safeTrack()` wrapper — catching errors from Vercel Analytics so they never surface to users — is a clean pattern. The typed event map means you can't typo an event name. Worth copying to every future project.
+
+**4. Test coverage improved despite scope expanding.**
+Sprint 1 ended at 97% coverage with 55 tests. Sprint 2 added significant new state logic (history, favourites, multiple storage keys, UI interactions) and still pushed to 100% line coverage. The test-gap-fill ticket at the end of the sprint is the right model.
+
+**5. CHANGELOG discipline held.**
+Every ticket included a CHANGELOG entry. The deploy ticket did a final verification pass. The document accurately reflects the sprint. This is a solvable operational habit — it just needs to be in the sprint structure.
+
+---
+
+### What Didn't Go Well
+
+**1. Merge conflicts from autonomous sprint-run without PR merges between waves.**
+
+The sprint executor ran multiple tickets and opened PRs before any were merged. Because all branches were off `main` at a fixed point, and because several tickets touched overlapping files (`ui.ts`, `style.css`, `state.ts`), PRs that were opened later conflicted with changes made by tickets executed earlier.
+
+The tickets with declared dependencies (`#33` ← `#32`, `#35` ← `#30 + #34`, etc.) were correctly sequenced, but the implementation files they all touched were effectively a shared surface. When `#36` (favourites data) and `#38` (visual refresh) both modified `ui.ts` independently, the second PR to reach GitHub had conflicts.
+
+**Root cause:** The sprint-run checkpoint model (open all PRs in a wave, then stop for merges) assumed ticket authors would write defensively against each other's branches. They wrote against `main`, which hadn't moved.
+
+**Mitigation already applied:** The sprint-run command has been updated. Future sprints will stop after each individual ticket, not after a whole wave, requiring a merge before the next ticket starts. This eliminates the conflict surface.
+
+**2. UX decisions in sprint planning lacked specialist review.**
+
+Looking at the shipped product, some UX choices are functional but not considered:
+- The favourites panel appears as a separate view with a toggle — but the transition is abrupt. There's no animation, no clear indication of where you "are" in the UI.
+- The action row has four icon buttons (copy, share, star, back, forward) with no labels. Icon-only buttons are a known accessibility risk — the `aria-label` attributes are there, but a first-time user has no visual affordance.
+- History position counter ("2 / 8") appears above the action row. A UX reviewer would likely question whether that's the right place, or whether the back/forward buttons should be more clearly paired with the counter.
+
+These aren't bugs. But they're the kind of decisions that benefit from someone asking "how does a user understand this?" before the code is written.
+
+**Root cause:** Sprint planning currently has no specialist review step. DECISIONS.md feeds the sprint brief, the sprint plan breaks it into tickets, and sprint-run executes. There's no moment where the UX agent (or any specialist) reviews the plan before execution begins.
+
+**See: Process Improvement #2 below for a proposed fix.**
+
+**3. The visual refresh (#38) was sequenced as "independent" but should have waited.**
+
+The sprint plan noted this risk: `#38` designs the action row, but `#33`, `#34`, `#35`, `#36`, `#37` all add buttons to the action row. The execution order worked in practice (visual refresh ran mid-sprint, after some features were stubbed), but the note in the sprint plan was a workaround, not a solution. A better dependency model would have `#38` explicitly depend on the feature tickets that define the action row's contents.
+
+---
+
+### What Surprised Us
+
+**1. 100% line coverage on a complex stateful codebase.**
+After adding history, favourites, copy, share, analytics — a lot of branching logic, async flows, and localStorage interaction — hitting 100% line coverage in the test gap-fill ticket was not a given. The test infrastructure established in Sprint 1 (Vitest + MSW + happy-dom) made it tractable.
+
+**2. The analytics module was generated cleanly on the first pass.**
+Typed event maps, `safeTrack()` error wrapper, `inject()` on load — this came out of a single ticket with no rework. It's a pattern worth templating for future projects.
+
+**3. The visual refresh is the biggest quality signal.**
+Functionally, every feature in this sprint could have been built on top of the Sprint 1 purple palette. The amber/cream refresh makes the app feel intentional. This is the first sprint where you could show it to someone and they wouldn't immediately say "tutorial project."
+
+---
+
+### What to Change — Process Improvements
+
+**Process Improvement #1: Sprint-run now stops after each ticket (already applied)**
+
+The sprint-run command has been updated to require a merge between each ticket rather than batching a wave. This eliminates the merge conflict surface. The trade-off is more manual intervention — but the alternative (debugging conflicts) costs more time.
+
+**Process Improvement #2: Specialist sprint plan review before execution**
+
+Currently: DECISIONS.md → sprint plan → sprint-run.
+
+Proposed: DECISIONS.md → sprint plan → **specialist review pass** → sprint-run.
+
+After `/sprint-plan` produces the plan, run one or more agent reviewers against it before committing to execution. The UX agent is the highest-value reviewer here — UX decisions that are made implicitly in a sprint plan (what does the favourites panel look like? how are icon buttons labelled?) get made explicitly by a specialist before any code is written.
+
+Concretely, add a `/sprint-plan-review` step (or fold it into `/sprint-plan`) where the UX agent (and optionally QA) reviews the proposed ticket list and surfaces interaction design decisions that need to be resolved before execution starts. These decisions get written into the ticket description, not left to the implementing agent to decide at runtime.
+
+**Trade-off:** Adds one step between planning and execution. Worth it for any ticket that involves new UI surfaces or interaction patterns.
+
+**Process Improvement #3: Parallelise non-conflicting tickets with sub-agents**
+
+Currently all ticket execution is synchronous — one ticket at a time, in sequence. With the new per-ticket merge checkpoint, this is even more sequential than Sprint 2 was.
+
+The opportunity: truly independent tickets (different files, no shared state) could run in parallel via sub-agents. In Sprint 2, `#30` (spike), `#31` (OG image), `#39` (analytics), and `#32` (history data layer) had zero file overlap. They could theoretically run concurrently.
+
+**Current constraint:** Claude Code doesn't natively parallelise ticket execution within a single sprint-run session. The Task tool can spawn sub-agents, but sub-agents don't have access to the git workflow tools (branch creation, commits, PR opening) in a way that's reliably composable back to the parent session.
+
+**Practical near-term approach:** Identify clearly independent tickets in the sprint plan (label them `parallel-safe`), and document them as candidates for running in separate terminal sessions simultaneously. This is a manual orchestration step — Joe could open two Claude Code sessions and run one ticket in each. Not automated, but faster than sequential for large sprints.
+
+**Longer-term:** Revisit as sub-agent tooling matures. The pattern is sound; the infrastructure constraint is the blocker.
+
+---
+
+## Reprioritisation
+
+### REVIEW.md Status After Sprint 2
+
+Phase 1: ✅ Complete
+Phase 2: ✅ Complete (all 12 tickets)
+Phase 3: Remaining
+
+### Phase 3 — Revised Priority Order
+
+Original Phase 3 list, re-evaluated after Sprint 2:
+
+| Item | Original Priority | Revised Priority | Notes |
+|------|-----------------|-----------------|-------|
+| Animated joke transitions | Medium | **High** | The crossfade from Sprint 2 is already there; full transitions are a polish pass that now makes sense |
+| Dark mode | Medium | **High** | CSS custom properties are fully wired; this is a sprint-hours job, not a sprint-days job |
+| PWA support | High | **Medium** | Genuinely useful (offline, install) but adds tooling complexity; sequence after polish work |
+| Joke rating system | Low | **Medium** | With favourites built, rating (thumbs up/down) is a small delta and high engagement signal |
+| "Joke of the day" permalink | Low | **Low** | Interesting but needs backend; out of scope for this project |
+| Generated OG images per joke | Low | **Low** | Cool but complex; Satori adds a build step; defer |
+| Performance budget | Medium | **High** | Lighthouse audit before calling Phase 3 done — this should be the exit gate |
+| Playwright E2E tests | Pushed from Sprint 2 | **High** | Explicitly deferred; Sprint 3 is the right time; needed before calling the project "production-grade" |
+| Search by keyword | Pushed from Sprint 2 | **Medium** | Still valuable; API supports it; but UI complexity means it's right here, not rushed |
+
+### Recommended Phase 3 Sprint Brief
+
+**Goal:** Polish, performance, and reach — make it something you'd put on a portfolio or ship as a side product.
+
+**In scope:**
+1. Dark mode (CSS custom properties already wired — small lift)
+2. Animated joke transitions (full crossfade/slide between jokes)
+3. Joke rating (thumbs up/down, localStorage, pairs with favourites)
+4. Search by keyword (API endpoint exists, needs search input UI)
+5. Playwright E2E tests (happy path + key user flows)
+6. Lighthouse/Core Web Vitals audit (performance budget gate)
+7. PWA: service worker + offline mode + install prompt
+8. UX agent review of Phase 3 plan before execution *(new, per retrospective)*
+
+**Sprint 3 recommended kickoff:** Run `/sprint-plan dad-jokes 3` after confirming the Phase 3 brief above.
+
+---
+
+## Next Sprint Preview
+
+**Sprint 3 goal:** "Make it impressive" — polish, offline capability, search, and an honest performance audit. Exit state: something you'd show at a job interview.
+
+**New tickets to create based on Sprint 2 learnings:**
+- `UX review of Sprint 3 plan` — run the UX agent against the sprint plan before execution starts
+- `Playwright E2E: happy path + favourites + history nav` — explicitly carried over from Sprint 2 deferral
+- `Lighthouse audit: baseline + pass` — performance budget gate; run before Sprint 3 review
+
+**Carry-over from Sprint 2:** None. All 12 tickets shipped.
+
+**Open epic:** #29 (Phase 2 epic) — can now be closed.
+
+---
+
+## Sprint Close
+
+- ✅ All 12 phase-2 issues closed
+- ✅ Epic #29 to be closed
+- ✅ REVIEW.md updated (Phase 2 marked complete)
+- ✅ CHANGELOG.md up to date
+- ✅ Deployed and verified
+- ✅ Phase 2 review written
+
+---
+
+*Sprint 2 reviewed 2026-02-23 by Claude Code (Scrum Master)*


### PR DESCRIPTION
## Summary

Applies the three process improvements identified in the Sprint 2 retrospective.

- **New `/sprint-plan-review` command** — UX + QA specialist review of a sprint plan before any code is written. Reads all tickets, asks the right design questions (empty states, icon-only button affordance, transitions, edge cases), annotates ticket descriptions with explicit decisions, and audits `parallel-safe` labels. Runs between `/sprint-plan` and `/sprint-run` for sprints with new UI surfaces.

- **`parallel-safe` label** — Tickets that touch entirely different files can be labelled `parallel-safe` in sprint planning. This signals to sprint-run/resume that they can be run in separate terminal sessions simultaneously. Sprint-plan now creates the label and knows to apply it during planning.

- **Per-ticket merge model** — Sprint-run and sprint-resume rewritten from a "build a whole wave, then stop" model to "build one ticket, stop for merge, repeat." This eliminates the merge conflict surface: each branch always cuts from a current `main`, so no two open PRs can conflict on the same files.

## Files changed

- `.claude/commands/sprint-plan-review.md` — new command
- `.claude/commands/sprint-plan.md` — add parallel-safe label creation + ticket annotation + after-planning prompt
- `.claude/commands/sprint-run.md` — rewrite to per-ticket model
- `.claude/commands/sprint-resume.md` — rewrite to per-ticket model  
- `CLAUDE.md` — document new workflow step, parallel-safe guidance, merge discipline
- `projects/dad-jokes/REVIEW.md` — Phase 2 marked complete, Sprint 2 learnings added
- `projects/dad-jokes/sprints/phase-2-review.md` — full Sprint 2 retro

## Test plan

- [ ] Review CLAUDE.md workflow section — new step 6 (plan review) is clear
- [ ] Review sprint-plan-review.md — command is actionable without ambiguity
- [ ] Review sprint-run.md — per-ticket handoff language is correct
- [ ] Verify sprint-resume.md matches sprint-run behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)